### PR TITLE
load averageが常時1未満の場合結果が返らない問題を修正

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -81,7 +81,7 @@ func (cli *CLI) Run(args []string) int {
 		var avgc float64
 		for i := 0; i < len(r.DsNames); i++ {
 			for n := 0; n < r.RowCnt; n++ {
-				v := math.Floor(r.ValueAt(i, n))
+				v := math.Ceil(r.ValueAt(i, n))
 
 				if v > 0 {
 					avgv += v


### PR DESCRIPTION
load averageが1未満の環境で実行した場合に結果が取得できない問題を修正しました
```
# prd example.com-load-load-g.rrd
[]
```

`r.ValueAt(i, n)` で `0.1234` のような値が返ると `math.Floor` によって `0` に変換されます
```
v := math.Floor(r.ValueAt(i, n))
```

すると以下の加算していく処理が行われず、結果が返りませんでした
```
if v > 0 {
        avgv += v
        if max < v {
                max = v
        }

        if min == 0 || v < min {
                min = v
        }
        avgc++
}
```